### PR TITLE
generate blog posts into /blog folder to fix navigation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,7 +28,7 @@ exports.createPages = ({ actions, graphql }) => {
     // create page for each mdx node
     posts.forEach(post => {
       createPage({
-        path: post.fields.slug,
+        path: `blog${post.fields.slug}`,
         component: blogPostTemplate,
         context: {
           slug: post.fields.slug,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "license": "0BSD",
   "scripts": {
-    "build": "gatsby build",
+    "build": "npm run clean && gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,4 +1,4 @@
-import { graphql } from "gatsby"
+import { graphql, Link} from "gatsby"
 import React from "react"
 import { Row, Col } from "react-bootstrap"
 import Container from "react-bootstrap/Container"
@@ -39,9 +39,9 @@ const Blog = ({ data }) => {
                     <h5 className="card-title">{title}</h5>
                     <p className="card-text">{post.frontmatter.date}</p>
                     <p className="card-text">{post.frontmatter.description}</p>
-                    <a href={post.slug} className="btn btn-primary">
+                    <Link to={post.slug} className={"btn btn-primary"}>
                       Olvasd tovább
-                    </a>
+                    </Link>
                   </div>
                 </div>
                 <br />


### PR DESCRIPTION
1. Used `Link` component to fix browser back navigation (history mismatch)
2. blog posts now rendered into `url/blog/2019-new-post` instead of `url/2019-new-post`
